### PR TITLE
web-components: lint/format/test を回す GitHub Actions CI を追加

### DIFF
--- a/.github/workflows/web-components-ci.yml
+++ b/.github/workflows/web-components-ci.yml
@@ -24,13 +24,13 @@ jobs:
         working-directory: assets/react-web-components
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # push 時に整形コミットを push できるよう、detached HEAD ではなくブランチを取得
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24 # 推奨 Node.js (最新 LTS)
           cache: npm

--- a/.github/workflows/web-components-ci.yml
+++ b/.github/workflows/web-components-ci.yml
@@ -1,5 +1,6 @@
 # assets/react-web-components (React + TypeScript + Vite) の lint / format / test を
 # 自動実行する CI。web-components 配下の変更時のみ動作する。
+# push 時は prettier 自動整形の結果をコミットして push し、フォーマット崩れを溜めない。
 name: web-components CI
 
 on:
@@ -13,7 +14,7 @@ on:
       - '.github/workflows/web-components-ci.yml'
 
 permissions:
-  contents: read # 最小限の読み取り権限のみ
+  contents: write # push 時に整形コミットを積むため
 
 jobs:
   lint-format-test:
@@ -24,6 +25,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # push 時に整形コミットを push できるよう、detached HEAD ではなくブランチを取得
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -38,8 +42,26 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # pull_request: フォーマット崩れを検知するのみ（fork PR は書き込み権限が無いため）
       - name: Format check
+        if: github.event_name == 'pull_request'
         run: npm run format:check
+
+      # push: prettier --write の結果に差分があれば整形コミットを積んで push する。
+      # GITHUB_TOKEN 由来の push は新たな workflow を再トリガーしないためループしない。
+      - name: Format and commit
+        if: github.event_name == 'push'
+        run: |
+          npx prettier --write "src/**/*.{ts,tsx,js,jsx,json,css,scss,md}"
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "整形差分なし。"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "[整形] prettier による自動整形 (CI)"
+          git push
 
       - name: Test
         run: npm run test

--- a/.github/workflows/web-components-ci.yml
+++ b/.github/workflows/web-components-ci.yml
@@ -6,9 +6,11 @@ on:
   pull_request:
     paths:
       - 'assets/react-web-components/**'
+      - '.github/workflows/web-components-ci.yml'
   push:
     paths:
       - 'assets/react-web-components/**'
+      - '.github/workflows/web-components-ci.yml'
 
 permissions:
   contents: read # 最小限の読み取り権限のみ

--- a/.github/workflows/web-components-ci.yml
+++ b/.github/workflows/web-components-ci.yml
@@ -1,0 +1,43 @@
+# assets/react-web-components (React + TypeScript + Vite) の lint / format / test を
+# 自動実行する CI。web-components 配下の変更時のみ動作する。
+name: web-components CI
+
+on:
+  pull_request:
+    paths:
+      - 'assets/react-web-components/**'
+  push:
+    paths:
+      - 'assets/react-web-components/**'
+
+permissions:
+  contents: read # 最小限の読み取り権限のみ
+
+jobs:
+  lint-format-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: assets/react-web-components
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24 # 推奨 Node.js (最新 LTS)
+          cache: npm
+          cache-dependency-path: assets/react-web-components/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Test
+        run: npm run test


### PR DESCRIPTION
## 概要

`assets/react-web-components/` の lint / format:check / test を GitHub Actions で自動実行する CI を追加する。

関連 Issue: https://github.com/thinkingreed-inc/F-RevoCRM/issues/1692

## 補足

- **本 PR は依存更新ブランチ `feature/1690-update-web-components-deps` に対して**出しています（main ではありません）。CI は依存更新後の環境（Node 24 / 最新依存）で回す必要があるためです。
- 動作内容: `assets/react-web-components/**` の変更時に Node 24 で `npm ci` → `npm run lint` → `npm run format:check` → `npm run test`。
- 現状ローカルでは 4 つとも green（lint は warning のみで 0 error）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
